### PR TITLE
Feature/14 lunch update 2019

### DIFF
--- a/comms/reproducible-research-dropin-ann.md
+++ b/comms/reproducible-research-dropin-ann.md
@@ -15,7 +15,7 @@ Everyone is welcome, there's no need to sign up or register. If you can't join o
 
 ## 2019 Schedule
 
-We're kicking off this term's activities with a ***pizza party*** hosted by [The Turing Way](https://github.com/alan-turing-institute/the-turing-way)! Join us on Tuesday 15th January at 4:30pm to catch up with the latest news about the project, share your suggestions and, of course, eat some delicious pizza :pizza: :yum:. Everyone is welcome, but it would be really helpful for catering purposes if you could sign up here.
+We're kicking off this term's activities with a ***pizza party*** hosted by [The Turing Way](https://github.com/alan-turing-institute/the-turing-way)! Join us on Tuesday 15th January at 4:30pm to catch up with the latest news about the project, share your suggestions and, of course, eat some delicious pizza :pizza: :yum:. Everyone is welcome, but it would be really helpful for catering purposes if you could sign up [here](https://goo.gl/forms/Nueao35HhVC01IAW2).
 
 Our regular ***lunchtime talks*** will get started on Monday 28th January, with Kirstie leading a session about FAIR - Findable, Accessible, Interoperable and Reusable - data.
 You can see the full term's schedule below - look out for next month's talks from our guest speakers Stephen Eglen and Paolo Missier.

--- a/comms/reproducible-research-dropin-ann.md
+++ b/comms/reproducible-research-dropin-ann.md
@@ -4,7 +4,7 @@
 
 **When:** Every other Monday, 1-2pm
 
-Starting from next Monday 15th October, research fellow Kirstie Whitaker, lead research software engineer Martin O'Reilly and research data scientist Louise Bowler will be hosting fortnightly informal lunch time sessions to discuss anything (and everything) related to reproducible research.
+Research fellow Kirstie Whitaker, lead research software engineer Martin O'Reilly and research data scientist Louise Bowler host fortnightly informal lunch time sessions to discuss anything (and everything) related to reproducible research.
 
 All too often research is published as "Trust me, I'm a scientist": there is no way for the reader to confirm the results that are presented. We want to make it *really easy* for all members of the Turing to provide the evidence for their work (the data and code that generates their results) along with their publications.
 
@@ -12,15 +12,33 @@ Each of the lunches will be themed around a challenge you see in making your res
 
 Everyone is welcome, there's no need to sign up or register. If you can't join on Monday lunchtimes, you're very welcome to email Kirstie (kwhitaker@turing.ac.uk), Martin (moreilly@turing.ac.uk) or Louise (lbowler@turing.ac.uk) or ping them a message in the [#reproducible-research Slack channel](https://alan-turing-institute.slack.com/messages/C6XEYUQPR).
 
-## Autumn 2018 Schedule
 
-Suggestions for future sessions are always welcome - get in touch with Kirstie, Martin or Louise via email or [Slack](https://alan-turing-institute.slack.com/messages/C6XEYUQPR).
+## 2019 Schedule
 
+We're kicking off this term's activities with a ***pizza party*** hosted by [The Turing Way](https://github.com/alan-turing-institute/the-turing-way)! Join us on Tuesday 15th January at 4:30pm to catch up with the latest news about the project, share your suggestions and, of course, eat some delicious pizza :pizza: :yum:. Everyone is welcome, but it would be really helpful for catering purposes if you could sign up here.
+
+Our regular ***lunchtime talks*** will get started on Monday 28th January, with Kirstie leading a session about FAIR - Findable, Accessible, Interoperable and Reusable - data.
+You can see the full term's schedule below - look out for next month's talks from our guest speakers Stephen Eglen and Paolo Missier.
+
+Suggestions for future sessions are always welcome - get in touch with Kirstie, Martin or Louise via email or [Slack](https://alan-turing-institute.slack.com/messages/C6XEYUQPR). We also have a few slots remaining in March and April if you'd like to run a session yourself.
 
 | Date                  | Topic                                                |
 | --------------------- | ---------------------------------------------------- |
+| _**Tuesday**_ 15th January | The Turing Way pizza party (4:30pm, location TBC) |
+| Monday 28th January   | FAIR data (Kirstie)                                  |
+| Monday 11th February  | CODECHECK ([Stephen Eglen](https://www.turing.ac.uk/people/researchers/stephen-eglen)) |
+| Monday 25th February  | Provenance for Data Science ([Paolo Missier](https://www.turing.ac.uk/people/researchers/paolo-missier)) |
+| Monday 11th March     | Examples of reproducible papers (Louise)             |
+| Monday 25th March     |                                                      |
+| Monday 8th April      |                                                      |
+
+
+
+## Previous Talks
+
+| Date                  | Topic                                                |
+| --------------------- | ---------------------------------------------------- |
+| 2018                  |                                                      |   
 | Monday 15th October   | Hacktoberfest (Kirstie)                              |
-| Monday 29th October   | [Sharing your work with Binder (Louise)](https://github.com/alan-turing-institute/ReproducibleResearchResources/blob/master/resources/binder.md)|
-| Monday 12th November  | Testing and Travis (Martin)                          |
-| Monday 26th November  | Codes of Conduct (Kirstie)                           |  |
-| Monday 10th December  | _No meeting due to [Data Study Group](https://www.turing.ac.uk/events/data-study-group-december-2018)_ |
+| Monday 29th October   | [Sharing your work with Binder](https://github.com/alan-turing-institute/ReproducibleResearchResources/blob/master/resources/binder.md) (Louise) |
+| Monday 12th November  | [Testing and Travis](https://github.com/alan-turing-institute/ReproducibleResearchResources/blob/master/resources/testing.md) (Martin) |

--- a/comms/reproducible-research-dropin-ann.md
+++ b/comms/reproducible-research-dropin-ann.md
@@ -24,7 +24,7 @@ Suggestions for future sessions are always welcome - get in touch with Kirstie, 
 
 | Date                  | Topic                                                |
 | --------------------- | ---------------------------------------------------- |
-| _**Tuesday**_ 15th January | The Turing Way pizza party (4:30pm, location TBC) |
+| _**Tuesday**_ 15th January | The Turing Way pizza party (4:30pm, Enigma) |
 | Monday 28th January   | FAIR data (Kirstie)                                  |
 | Monday 11th February  | CODECHECK ([Stephen Eglen](https://www.turing.ac.uk/people/researchers/stephen-eglen)) |
 | Monday 25th February  | Provenance for Data Science ([Paolo Missier](https://www.turing.ac.uk/people/researchers/paolo-missier)) |


### PR DESCRIPTION
#14: This PR updates the reproducible research dropin page with the talk schedule for early 2019 and details of the pizza party for the Turing Way.